### PR TITLE
Handle missing to/cc headers when extracting aliases from BCC-only emails

### DIFF
--- a/lib/extractEmailAliases.ts
+++ b/lib/extractEmailAliases.ts
@@ -7,7 +7,9 @@ import { operationalDomain } from "./env";
  * in the email belonging to user's verified domain.
  */
 export default (parsed: ParsedMail): Array<string> => {
-  const recipients = parsed.to.value.concat(parsed.cc ? parsed.cc.value : []);
+  const toRecipients = parsed.to?.value ?? [];
+  const ccRecipients = parsed.cc?.value ?? [];
+  const recipients = toRecipients.concat(ccRecipients);
 
   return recipients
     .filter(emailObject => emailObject.address !== undefined)


### PR DESCRIPTION
Sometimes there are emails, such as those from GitHub, will have only BCC recipients without To or Cc headers, which will result a `TypeError: Cannot read property 'value' of undefined` error. This commits fix that by doing a null coercion to empty array to resolve it.
